### PR TITLE
Add Official Support for Motorola One Power (chef)

### DIFF
--- a/changelog_chef.txt
+++ b/changelog_chef.txt
@@ -1,0 +1,8 @@
+Highlights & Device Specific Changes:
+Build type: Monthly
+Device: Motorola One Power (chef)
+Device maintainer: Rushi Ranpise (rushi24)
+
+
+===== 8 April, 2022 =====
+- Initial Release

--- a/chef.json
+++ b/chef.json
@@ -1,0 +1,28 @@
+{
+  "response": [
+    {
+        "maintainer": "Rushi Ranpise (rushi24)",
+        "oem": "Motorola",
+        "device": "Motorola One Power",
+        "filename": "crDroidAndroid-12.1-20220408-chef-v8.4.zip",
+        "download": "https://sourceforge.net/projects/crdroid/files/chef/8.x/crDroidAndroid-12.1-20220408-chef-v8.4.zip/download",
+        "timestamp": 1649376623,
+        "md5": "fc006f81a4980ea4a48231745334cde6",
+        "sha256": "57a8c1e946d6a18314ac1515412e7bc4d389a3a150b1961b46312e262529e98c",
+        "size": 850556123,
+        "version": "8.4",
+        "buildtype": "Monthly",
+        "forum": "https://forum.xda-developers.com/t/unofficial-rom-12-chef-crdroid-v8-x-los.4428025/",
+        "gapps": "",
+        "firmware": "",
+        "modem": "",
+        "bootloader": "",
+        "recovery": "https://dl.twrp.me/chef/",
+        "paypal": "",
+        "telegram": "https://t.me/motorolaonepower",
+        "dt": "https://github.com/crdroidandroid/android_device_motorola_chef",
+        "common-dt": "https://github.com/crdroidandroid/android_device_motorola_sdm660-common",
+        "kernel": "https://github.com/crdroidandroid/android_kernel_motorola_msm8998"
+    }
+  ]
+}


### PR DESCRIPTION
As discussed creating pull request to add Motorola One Power (chef) to official supported device.