### PR TITLE
Add initial support for OnePlus 6 & 6T under Android 13

### DIFF
--- a/changelog_enchilada.txt
+++ b/changelog_enchilada.txt
@@ -1,0 +1,176 @@
+crDroid 9.0
+
+Changelog for initial Android 13 release (notable changes moving forward from Android 12 device trees/kernel):
+- Merged November ASB & changes from upstream LineageOS device/kernel/vendor trees.
+- It's a new major Android version; if you want to see changes since previous testing builds, join the Telegram group.
+- Kernel updated to 4.9.333 with updates merged from Google's AOSP 4.9 LTS repository (thanks to BananaFunction).
+- Updated my stack of kernel commits, including refreshed wifi & power commits and numerous other tweaks from MCD kernel r19 (thanks, Danny! <3).
+- Kernel adreno driver should no longer aggressively try to downclock GPU below 40% battery (causing everything to be sluggish regardless of CPU settings).
+- NFC stack is now built from source, and some security authentication apps might struggle running under Android 13. NFC itself seems to be working fine & Google Wallet for contactless payment seems to be working fine.
+- I would've gotten this release out a month ago except it took that long to figure out how to get OnePlus Camera & Gallery back to 100% working again (huge thanks to Weritos & jabashque).
+- Dropped "Multiple intensities" vibration option from Accessibility/haptics, since it never actually worked correctly. Use DeviceExtras for controlling vibration strength.
+- Look, DASH charging & Smart Charging and a bunch of other things took way more work to figure out how to get them to behave (nearly) the same as they did before than they should have.Takes time to make it appear like a simple, easy update.
+
+Known issues:
+- Users upgrading from 8.x should plan on doing a clean flash, and again, MindTheGapps is the recommended Google Apps package. If you don't, you might have issues with NFC, OnePlus Camera/Gallery, itchiness, frequent/painful urination, and in very few cases spontaneous human combustion. Safety not guaranteed.
+- Smart charging doesn't always stop exactly at the specified percentage when using a DASH charger or when device is in deep sleep. That's as smart as it gets for initial Android 13 release.
+- "Haptic feedback on Back gesture" feature doesn't actually work yet. Needs investigation after we worry about updating to December ASB sources.
+- Haptic feedback for tri-state-key disappears when you turn off "touch feedback" haptics now, when it wasn't like that before. Android 13, amirite?
+- Custom fonts don't apply properly to 3rd party apps. It's in the crDroid GitHub issue tracker already.
+- You tell me, with logs!
+
+Installation notes:
+- Plan on doing a clean flash when changing major Android system versions (so if you're coming from crDroid 8, and want to give me a bug report, because I'll ignore you otherwise). Back up your data first of course. After this initial clean flash for Android 13, it should be fine to just use the built-in Updater in Settings > System > Updates for future updates.
+- If you're coming from stock or another ROM, reboot to bootloader and fastboot flash the boot.img for your device (enchilada or fajita) to both boot slots, then reboot to bootloader again *so it actually loads the new recovery ramdisk*.
+- YOU SHOULD INSTALL FROM CRDROID RECOVERY, since we can't do a clean flash from built-in updater, and we DON'T want to run addon.d scripts because you need to update to a newer GApps package. So follow the regular adb sideloading process from recovery (reboot recovery, format data if doing clean install, adb sideload ROM zip, reboot recovery to trigger slot switch, adb sideload GApps/microG/magisk/whatever, reboot system).
+- See XDA thread for troubleshooting installation issues, or other common issues including problems with OxygenOS Camera & Gallery.
+
+Build type: Monthly (-ish)
+Device: OnePlus 6 (enchilada)
+Device maintainer: Jordan Whiteley (Terminator_J)
+Required firmware: OxygenOS 11.1.2.2
+
+====================
+     12-13-2022
+====================
+
+   * frameworks/base
+80848dad661b PowerManacerService: Fix hard reboot with 'Reset Battery Stats' enabled for Smart Charging
+
+====================
+     12-09-2022
+====================
+
+   * packages/apps/Aperture
+6a7ebbb Aperture: Allow adding additional video configurations
+a07126e Aperture: Associate video qualities to available framerates
+
+====================
+     12-08-2022
+====================
+
+   * frameworks/base
+0f6d89e9018b fixup! Rewrite trust USB restriction handling
+
+   * packages/apps/Aperture
+87f64b8 Aperture: Calculate intrinsic zoom ratio from view angle degrees
+b9a77ee Aperture: Rename zoomRatio to intrinsicZoomRatio
+da18065 Aperture: Introduce Sensor interface
+43c6a75 Aperture: Drop logical multi-camera support in lens selector
+467c781 Aperture: Implement image/video stabilization
+54d565b Aperture: Implement video framerate switch
+5048d2e Aperture: Add code for Camera2 interop
+6b71eb5 Aperture: Move to AndroidX Media3 for video capture preview
+5216c09 Aperture: Don't handle keypresses when capture preview is open
+
+   * packages/inputmethods/LatinIME
+fd734764d LatinIME: Theme swipe elements with Material You styling
+
+====================
+     12-07-2022
+====================
+
+   * device/google/atv
+a1807ac Partially revert "Enabling Apex in BT"
+
+   * frameworks/base
+b0e1754ea054 New Crowdin updates (#914)
+
+   * packages/apps/Dialer
+6f94a5b13 New translations (#37)
+
+   * packages/apps/Launcher3
+cdef41062d New Crowdin updates (#299)
+
+   * packages/apps/crDroidSettings
+ce978484 New Crowdin updates (#992)
+
+====================
+     12-06-2022
+====================
+
+   * frameworks/av
+e3f8fb28b3 libcameraservice: add TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB
+7925761bd6 Revert "DNM Revert "Camera: Add support for readout timestamp""
+
+   * frameworks/base
+b375b48372c6 Revert "DNM Revert "Camera: Add support for readout timestamp""
+87f5354d6bff RELAND MediaCodec: don't cache buffers until requested
+2ce3f2dc6a99 audio: add support for extended formats
+a00b91f3295c Revert "Power menu styles: Initial checkin for T [1/2]"
+
+   * packages/apps/Jelly
+b43dfea Jelly: Fix CoarseFineLocation lint issue
+cb3ab6e Jelly: Skip null MIME types in file chooser
+
+   * packages/apps/crDroidSettings
+b30cbcf6 Revert "crdroid: Power menu styles [2/2]"
+
+====================
+     12-05-2022
+====================
+
+   * frameworks/base
+ff6bd5165eb3 Screenrecord: Add summary for HEVC encoding
+89d468e064f7 Screenrecord: Add an option to use HEVC
+983b5b4febc5 Screenrecord: Slightly optimize loading/saving preferences
+6f114cc0d071 Screenrecord: Allow to reduce 3 second screen record timer
+81f5beb57a8c Revert "Fix network leaks with split-tunnel VPNs"
+
+====================
+     12-04-2022
+====================
+
+   * android
+e4cb9f3 Merge 'lineage-20.0' into 13.0
+0484170 manifest: Track our own android_external_avb
+
+   * bionic
+b7fc80a70 libc: Add TARGET_ALTERNATIVE_FUTEX_WAITERS
+
+   * build/make
+29a2881a5 build: dont include tasks from tests and platform_testing
+656277bcc sign_target_files_apks: Fix avbtool usage
+4a210d36e Use Unix epoch time for build number
+fa5f8b7e1 Don't build QuickSearchBox
+2c43b8654 Fix potential error for sys.platform
+41de3c3f6 core: Disable Dalvik lock contention logging
+1d2964035 combo: Add cortex-a76 to known v8-2a cores
+887f49f90 Fix coredump_enable() in envsetup.sh
+f1fae202c envsetup.sh: cleanup ccache echo
+46d59071e envsetup: Fix indentation in ccache code snippet
+38b161836 envsetup: export the CCACHE_DIR if its not set
+60cfd2b81 envsetup: Prefer setting ccache compress as command line parameter
+55c053ae4 Automatically set CCACHE_EXEC to the system's ccache
+a78a6492d build: execute changelog generator script
+8cfee7245 build: Add ANSI name and build info
+5a2bd3f5c Make build ID simple
+01fb3feb1 build: Always use release-keys
+43471cabb build: Add backuptool by default
+ffbcdc1ed envsetup: Automatically set CCACHE_EXEC to the system's ccache
+e6432e97d build: Add ro.crdroid.device
+
+   * frameworks/base
+4b9b00e9ecc7 Change DropboxRateLimiter to rate limit proto tombstones and regular tombstones separately.
+26b0516e4a38 fix MediaRouter error callback
+1489d6d646e1 Fix BluetoothRouteProvider unsync randon crash
+73ece58359d4 Apply wakelock for notification sound
+1497ef9f4617 Change the order of Notification writeToParcel
+4c9b806df305 Do not assistant delay for media notifications
+3451b6503c39 Return no optmization info for package "android".
+81036f144222 neko/Cat: Mark FLAG_IMMUTABLE PendingIntent with FLAG_MUTABLE
+0053aaf3819f frameworks: Reset battery stats [1/3]
+9bc67ce4c7d3 BatteryStatsImpl: Stop resetting battery stats after reboot
+
+   * packages/apps/Dialer
+39289a330 use aidl: local_include_dirs
+
+   * packages/apps/Settings
+ca402053d7 Only one channel is reserved for WifiP2pSettings
+7a9f345e72 Settings: Reset battery stats [2/3]
+
+   * packages/apps/crDroidSettings
+5fd62763 crdroid: Reset battery stats [3/3]
+
+   * packages/services/Telecomm
+fdb1f3da8 Fix dark navigationBar background in some telephony settings pages

--- a/changelog_fajita.txt
+++ b/changelog_fajita.txt
@@ -1,0 +1,176 @@
+crDroid 9.0
+
+Changelog for initial Android 13 release (notable changes moving forward from Android 12 device trees/kernel):
+- Merged November ASB & changes from upstream LineageOS device/kernel/vendor trees.
+- It's a new major Android version; if you want to see changes since previous testing builds, join the Telegram group.
+- Kernel updated to 4.9.333 with updates merged from Google's AOSP 4.9 LTS repository (thanks to BananaFunction).
+- Updated my stack of kernel commits, including refreshed wifi & power commits and numerous other tweaks from MCD kernel r19 (thanks, Danny! <3).
+- Kernel adreno driver should no longer aggressively try to downclock GPU below 40% battery (causing everything to be sluggish regardless of CPU settings).
+- NFC stack is now built from source, and some security authentication apps might struggle running under Android 13. NFC itself seems to be working fine & Google Wallet for contactless payment seems to be working fine.
+- I would've gotten this release out a month ago except it took that long to figure out how to get OnePlus Camera & Gallery back to 100% working again (huge thanks to Weritos & jabashque).
+- Dropped "Multiple intensities" vibration option from Accessibility/haptics, since it never actually worked correctly. Use DeviceExtras for controlling vibration strength.
+- Look, DASH charging & Smart Charging and a bunch of other things took way more work to figure out how to get them to behave (nearly) the same as they did before than they should have. Takes time to make it appear like a simple, easy update.
+
+Known issues:
+- Users upgrading from 8.x should plan on doing a clean flash, and again, MindTheGapps is the recommended Google Apps package. If you don't, you might have issues with NFC, OnePlus Camera/Gallery, itchiness, frequent/painful urination, and in very few cases spontaneous human combustion. Safety not guaranteed.
+- Smart charging doesn't always stop exactly at the specified percentage when using a DASH charger or when device is in deep sleep. That's as smart as it gets for initial Android 13 release.
+- "Haptic feedback on Back gesture" feature doesn't actually work yet. Needs investigation after we worry about updating to December ASB sources.
+- Haptic feedback for tri-state-key disappears when you turn off "touch feedback" haptics now, when it wasn't like that before. Android 13, amirite?
+- Custom fonts don't apply properly to 3rd party apps. It's in the crDroid GitHub issue tracker already.
+- You tell me, with logs!
+
+Installation notes:
+- Plan on doing a clean flash when changing major Android system versions (so if you're coming from crDroid 8, and want to give me a bug report, because I'll ignore you otherwise). Back up your data first of course. After this initial clean flash for Android 13, it should be fine to just use the built-in Updater in Settings > System > Updates for future updates.
+- If you're coming from stock or another ROM, reboot to bootloader and fastboot flash the boot.img for your device (enchilada or fajita) to both boot slots, then reboot to bootloader again *so it actually loads the new recovery ramdisk*.
+- YOU SHOULD INSTALL FROM CRDROID RECOVERY, since we can't do a clean flash from built-in updater, and we DON'T want to run addon.d scripts because you need to update to a newer GApps package. So follow the regular adb sideloading process from recovery (reboot recovery, format data if doing clean install, adb sideload ROM zip, reboot recovery to trigger slot switch, adb sideload GApps/microG/magisk/whatever, reboot system).
+- See XDA thread for troubleshooting installation issues, or other common issues including problems with OxygenOS Camera & Gallery.
+
+Build type: Monthly (-ish)
+Device: OnePlus 6T (fajita)
+Device maintainer: Jordan Whiteley (Terminator_J)
+Required firmware: OxygenOS 11.1.2.2
+
+====================
+     12-13-2022
+====================
+
+   * frameworks/base
+80848dad661b PowerManacerService: Fix hard reboot with 'Reset Battery Stats' enabled for Smart Charging
+
+====================
+     12-09-2022
+====================
+
+   * packages/apps/Aperture
+6a7ebbb Aperture: Allow adding additional video configurations
+
+====================
+     12-08-2022
+====================
+
+   * frameworks/base
+0f6d89e9018b fixup! Rewrite trust USB restriction handling
+
+   * packages/apps/Aperture
+a07126e Aperture: Associate video qualities to available framerates
+87f64b8 Aperture: Calculate intrinsic zoom ratio from view angle degrees
+b9a77ee Aperture: Rename zoomRatio to intrinsicZoomRatio
+da18065 Aperture: Introduce Sensor interface
+43c6a75 Aperture: Drop logical multi-camera support in lens selector
+467c781 Aperture: Implement image/video stabilization
+54d565b Aperture: Implement video framerate switch
+5048d2e Aperture: Add code for Camera2 interop
+6b71eb5 Aperture: Move to AndroidX Media3 for video capture preview
+5216c09 Aperture: Don't handle keypresses when capture preview is open
+
+   * packages/inputmethods/LatinIME
+fd734764d LatinIME: Theme swipe elements with Material You styling
+
+====================
+     12-07-2022
+====================
+
+   * device/google/atv
+a1807ac Partially revert "Enabling Apex in BT"
+
+   * frameworks/base
+b0e1754ea054 New Crowdin updates (#914)
+
+   * packages/apps/Dialer
+6f94a5b13 New translations (#37)
+
+   * packages/apps/Launcher3
+cdef41062d New Crowdin updates (#299)
+
+   * packages/apps/crDroidSettings
+ce978484 New Crowdin updates (#992)
+
+====================
+     12-06-2022
+====================
+
+   * frameworks/av
+e3f8fb28b3 libcameraservice: add TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB
+7925761bd6 Revert "DNM Revert "Camera: Add support for readout timestamp""
+
+   * frameworks/base
+b375b48372c6 Revert "DNM Revert "Camera: Add support for readout timestamp""
+87f5354d6bff RELAND MediaCodec: don't cache buffers until requested
+2ce3f2dc6a99 audio: add support for extended formats
+a00b91f3295c Revert "Power menu styles: Initial checkin for T [1/2]"
+
+   * packages/apps/Jelly
+b43dfea Jelly: Fix CoarseFineLocation lint issue
+cb3ab6e Jelly: Skip null MIME types in file chooser
+
+   * packages/apps/crDroidSettings
+b30cbcf6 Revert "crdroid: Power menu styles [2/2]"
+
+====================
+     12-05-2022
+====================
+
+   * frameworks/base
+ff6bd5165eb3 Screenrecord: Add summary for HEVC encoding
+89d468e064f7 Screenrecord: Add an option to use HEVC
+983b5b4febc5 Screenrecord: Slightly optimize loading/saving preferences
+6f114cc0d071 Screenrecord: Allow to reduce 3 second screen record timer
+81f5beb57a8c Revert "Fix network leaks with split-tunnel VPNs"
+
+====================
+     12-04-2022
+====================
+
+   * android
+e4cb9f3 Merge 'lineage-20.0' into 13.0
+0484170 manifest: Track our own android_external_avb
+
+   * bionic
+b7fc80a70 libc: Add TARGET_ALTERNATIVE_FUTEX_WAITERS
+
+   * build/make
+29a2881a5 build: dont include tasks from tests and platform_testing
+656277bcc sign_target_files_apks: Fix avbtool usage
+4a210d36e Use Unix epoch time for build number
+fa5f8b7e1 Don't build QuickSearchBox
+2c43b8654 Fix potential error for sys.platform
+41de3c3f6 core: Disable Dalvik lock contention logging
+1d2964035 combo: Add cortex-a76 to known v8-2a cores
+887f49f90 Fix coredump_enable() in envsetup.sh
+f1fae202c envsetup.sh: cleanup ccache echo
+46d59071e envsetup: Fix indentation in ccache code snippet
+38b161836 envsetup: export the CCACHE_DIR if its not set
+60cfd2b81 envsetup: Prefer setting ccache compress as command line parameter
+55c053ae4 Automatically set CCACHE_EXEC to the system's ccache
+a78a6492d build: execute changelog generator script
+8cfee7245 build: Add ANSI name and build info
+5a2bd3f5c Make build ID simple
+01fb3feb1 build: Always use release-keys
+43471cabb build: Add backuptool by default
+ffbcdc1ed envsetup: Automatically set CCACHE_EXEC to the system's ccache
+e6432e97d build: Add ro.crdroid.device
+
+   * frameworks/base
+4b9b00e9ecc7 Change DropboxRateLimiter to rate limit proto tombstones and regular tombstones separately.
+26b0516e4a38 fix MediaRouter error callback
+1489d6d646e1 Fix BluetoothRouteProvider unsync randon crash
+73ece58359d4 Apply wakelock for notification sound
+1497ef9f4617 Change the order of Notification writeToParcel
+4c9b806df305 Do not assistant delay for media notifications
+3451b6503c39 Return no optmization info for package "android".
+81036f144222 neko/Cat: Mark FLAG_IMMUTABLE PendingIntent with FLAG_MUTABLE
+0053aaf3819f frameworks: Reset battery stats [1/3]
+9bc67ce4c7d3 BatteryStatsImpl: Stop resetting battery stats after reboot
+
+   * packages/apps/Dialer
+39289a330 use aidl: local_include_dirs
+
+   * packages/apps/Settings
+ca402053d7 Only one channel is reserved for WifiP2pSettings
+7a9f345e72 Settings: Reset battery stats [2/3]
+
+   * packages/apps/crDroidSettings
+5fd62763 crdroid: Reset battery stats [3/3]
+
+   * packages/services/Telecomm
+fdb1f3da8 Fix dark navigationBar background in some telephony settings pages

--- a/enchilada.json
+++ b/enchilada.json
@@ -1,0 +1,28 @@
+{
+	"response": [
+		{
+			"maintainer": "Jordan Whiteley (Terminator_J)",
+			"oem": "OnePlus",
+			"device": "OnePlus 6",
+			"filename": "crDroidAndroid-13.0-20221213-enchilada-v9.0.zip",
+			"download": "https://sourceforge.net/projects/crdroid/files/enchilada/9.x/crDroidAndroid-13.0-20221213-enchilada-v9.0.zip/download",
+			"timestamp": 1670979039,
+			"md5": "49792b772e3d8285a85e9211ab6db63e",
+			"sha256": "082c449c24a740b948d8365ec0e5bbb5b42d1ed2eb6e2a295d2cca8eb5358f89",
+			"size": 1045573191,
+			"version": "9.0",
+			"buildtype": "Monthly",
+			"forum": "https://forum.xda-developers.com/t/rom-13-0_r13-official-crdroid-android-v9-0.4528047/post-87834511",
+			"gapps": "https://androidfilehost.com/?w=files&flid=322935",
+			"firmware": "https://otafsg1.h2os.com/patch/amazone2/GLO/OnePlus6Oxygen/OnePlus6Oxygen_22.J.62_GLO_0620_2111252336/OnePlus6Oxygen_22.J.62_OTA_0620_all_2111252336_14afec75dd6fa.zip",
+			"modem": "",
+			"bootloader": "",
+			"recovery": "",
+			"paypal": "https://www.paypal.me/terminatorj",
+			"telegram": "https://t.me/crdroidoneplus6_6t",
+			"dt": "https://github.com/crdroidandroid/android_device_oneplus_enchilada",
+			"common-dt": "https://github.com/crdroidandroid/android_device_oneplus_sdm845-common",
+			"kernel": "https://github.com/crdroidandroid/android_kernel_oneplus_sdm845"
+		}
+	]
+}

--- a/fajita.json
+++ b/fajita.json
@@ -1,0 +1,28 @@
+{
+	"response": [
+		{
+			"maintainer": "Jordan Whiteley (Terminator_J)",
+			"oem": "OnePlus",
+			"device": "OnePlus 6T",
+			"filename": "crDroidAndroid-13.0-20221213-fajita-v9.0.zip",
+			"download": "https://sourceforge.net/projects/crdroid/files/fajita/9.x/crDroidAndroid-13.0-20221213-fajita-v9.0.zip/download",
+			"timestamp": 1670986093,
+			"md5": "6e4a66114a5a7d4fa543f5f83f9b90b3",
+			"sha256": "7fbb3d592d1281732dedceb36ca0daa491c06fc011bbade51edb151f59801309",
+			"size": 1196920631,
+			"version": "9.0",
+			"buildtype": "Monthly",
+			"forum": "https://forum.xda-developers.com/t/rom-13-0_r13-official-crdroid-android-v9-0.4528047/post-87834511",
+			"gapps": "https://androidfilehost.com/?w=files&flid=322935",
+			"firmware": "https://otafsg1.h2os.com/patch/amazone2/GLO/OnePlus6TOxygen/OnePlus6TOxygen_34.J.62_GLO_0620_2111252336/OnePlus6TOxygen_34.J.62_OTA_0620_all_2111252336_339a2fa8335f21.zip",
+			"modem": "",
+			"bootloader": "",
+			"recovery": "",
+			"paypal": "https://www.paypal.me/terminatorj",
+			"telegram": "https://t.me/crdroidoneplus6_6t",
+			"dt": "https://github.com/crdroidandroid/android_device_oneplus_fajita",
+			"common-dt": "https://github.com/crdroidandroid/android_device_oneplus_sdm845-common",
+			"kernel": "https://github.com/crdroidandroid/android_kernel_oneplus_sdm845"
+		}
+	]
+}


### PR DESCRIPTION
Hardware features are working on par with upstream LineageOS, and basically all working well (BT & audio, NFC, WiFi, RIL, vibration, regular & DASH charging, camera & microphones, alert slider, etc).
With the "TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB" patches added to frameworks/av/ and vendor/lineage [crdroid]/, OnePlus Camera & Gallery features are working 100% again.
Smart Charging is occasionally not very smart when device is in deep sleep and will go a little higher than target percentage before it stops, but it's generally reliable. Pocket mode & UDFPS (especially from screen-off) work better in 13 than they ever did in 12, amazing.
Have done 6-7 beta builds and another five-ish release candidates over the last month and a half and it feels really solid now.

Can these be added as two separate commits so that it generates both device links in the Releases group? :D