### PR TITLE
Adding new official device - Xiaomi Pad 5 (nabu)

### DIFF
--- a/changelog_nabu.txt
+++ b/changelog_nabu.txt
@@ -1,0 +1,11 @@
+Highlights & Device Specific Changes:
+Build type: Beta
+Device: Xiaomi Pad 5 (nabu)
+Device maintainer:  EleazerEnnis (Elee)
+
+
+===== 23th July, 2023=====
+
+- Initial crDroid 9.7 release
+- Updated to July 2023 security patches
+- Some fixes here and there

--- a/nabu.json
+++ b/nabu.json
@@ -1,0 +1,28 @@
+{
+	"response": [
+		{
+			"maintainer": "EleazerEnnis",
+			"oem": "OEM",
+			"device": "nabu",
+			"filename": "crDroidAndroid-13.0-20230722-nabu-v9.7.zip",
+			"download": "https://sourceforge.net/projects/crdroid/files/nabu/9.x/crDroidAndroid-13.0-20230722-nabu-v9.7.zip/download",
+			"timestamp": 1690039048,
+			"md5": "068c6dac45357905135590b7c345b4a2",
+			"sha256": "a8ffe41b738e034bbff6a644895856d9c3eeacd99c108d1500ff1f5d69811097",
+			"size": 1138984280,
+			"version": "9.7",
+			"buildtype": "Beta",
+			"forum": "https://forum.xda-developers.com/t/rom-android13-crdroid-official-xiaomi-pad-5-nubu-23th-july-2023.4608397/",
+			"gapps": "",
+			"firmware": "",
+			"modem": "",
+			"bootloader": "",
+			"recovery": "",
+			"paypal": "",
+			"telegram": "",
+			"dt": "https://github.com/crdroidandroid/android_device_xiaomi_nabu",
+			"common-dt": "",
+			"kernel": "https://github.com/crdroidandroid/android_kernel_xiaomi_nabu"
+		}
+	]
+}

--- a/nabu.json
+++ b/nabu.json
@@ -2,8 +2,8 @@
 	"response": [
 		{
 			"maintainer": "EleazerEnnis",
-			"oem": "OEM",
-			"device": "nabu",
+			"oem": "Xiaomi",
+			"device": "Xiaomi Pad 5",
 			"filename": "crDroidAndroid-13.0-20230722-nabu-v9.7.zip",
 			"download": "https://sourceforge.net/projects/crdroid/files/nabu/9.x/crDroidAndroid-13.0-20230722-nabu-v9.7.zip/download",
 			"timestamp": 1690039048,


### PR DESCRIPTION
Hello team,

I'm excited to contribute to this project and would like to introduce support for the Xiaomi Pad 5 as a new officially maintained device.
Device Information:
Device Name: Xiaomi Pad 5
Codename: nabu
CPU Architecture: arm64
Android Version: Android 13
Manufacturer: Xiaomi

I've thoroughly tested the device-specific changes and verified that the device functions properly with the project's latest build. The device has passed basic functionality tests, including Wi-Fi, Bluetooth, camera, and other essential features.
I would greatly appreciate your feedback on the implementation and any suggestions for improvement. I'm committed to maintaining the highest code quality and adhering to the project's coding standards.
Looking forward to contributing more in the future!

Thank you for considering my contribution!